### PR TITLE
Packaging Fixes for Python 2 and 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# OSX
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ When a service receives a request with an OAuth bearer token, it verifies the to
 ### For Micro Service
 
 ```
-pip install -e https://github.com/coupa/sand-python
+pip install git+https://github.com/coupa/sand-python.git
 ```

--- a/sand_python/__init__.py
+++ b/sand_python/__init__.py
@@ -1,1 +1,4 @@
 name = "sand_python"
+from .sand_exceptions import SandError
+from .sand_service import SandService
+from .sand_client import SandClient

--- a/sand_python/requirements.txt
+++ b/sand_python/requirements.txt
@@ -1,3 +1,0 @@
-requests
-datetime
-json

--- a/sand_python/sand_client.py
+++ b/sand_python/sand_client.py
@@ -1,7 +1,7 @@
 import time
 import requests
-from sand_service import SandService
-from sand_exceptions import SandError
+from .sand_service import SandService
+from .sand_exceptions import SandError
 
 class SandClient():
 

--- a/sand_python/sand_service.py
+++ b/sand_python/sand_service.py
@@ -8,7 +8,7 @@ import json
 import re
 import requests
 from dateutil import parser
-from sand_exceptions import SandError
+from .sand_exceptions import SandError
 
 class SandService():
     """

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,7 @@ setup(
     ],
     keywords='sand',
     install_requires=[
+        'requests==2.20.1',
+        'python-dateutil==2.7.5'
     ]
 )


### PR DESCRIPTION
Packaging fixes when installing and using sand-python

tested on python 2.7.5 and 3.7.1